### PR TITLE
Fix for when no pagaination options

### DIFF
--- a/lib/generators/index.js
+++ b/lib/generators/index.js
@@ -28,7 +28,7 @@ var index = function(opts) {
 		var paginationOptions = {
 			page: req.query.page,
 			// use setting in query paramsor global custom setting
-			perPage: req.query.perPage || options.pagination.perPage
+			perPage: req.query.perPage || (options.pagination ? options.pagination.perPage : undefined)
 		};
 
 		pagination.query(query, paginationOptions, function(err, results) {


### PR DESCRIPTION
When no perPage option was passed in a query param or options.pagination was undefined then an error occurred because the perPage was being looked for an undefined object.

Fix is to use a ternary on options.pagination to account for when that property is undefined