### PR TITLE
Add the ability to add a custom error for not found resources

### DIFF
--- a/lib/generators/show.js
+++ b/lib/generators/show.js
@@ -3,6 +3,8 @@ var _ = require('lodash');
 var show = function(options) {
 	var _this = this;
 	var Model = this.Model;
+	var options = this.options;
+	var customErrors = options.errors || {};
 
 	return function show(req, res, next) {
 		var query;
@@ -26,7 +28,13 @@ var show = function(options) {
 				return next(err);
 			}
 			if (!model) {
-				return res.status(404).json({});
+				res.status(404);
+				// if no custom error defined, just res empty object
+				if (!customErrors.notFound) {
+					return res.json({});
+				}
+				// custom error was defined, pass that on
+				return next(customErrors.notFound());
 			}
 			res.json(model);
 		});

--- a/lib/generators/update.js
+++ b/lib/generators/update.js
@@ -2,6 +2,8 @@ var _ = require('lodash');
 
 var update = function(options) {
 	var Model = this.Model;
+	var options = this.options;
+	var customErrors = options.errors || {};
 
 	return function update(req, res, next) {
 		var data = req.body || {};
@@ -12,6 +14,15 @@ var update = function(options) {
 		Model.findById(modelId, function(err, model) {
 			if (err) {
 				return next(err);
+			}
+			if (!model) {
+				res.status(404);
+				// if no custom error defined, just res empty object
+				if (!customErrors.notFound) {
+					return res.json({});
+				}
+				// custom error was defined, pass that on
+				return next(customErrors.notFound());
 			}
 
 			model = _.extend(model, data);

--- a/test/custom-error-test.js
+++ b/test/custom-error-test.js
@@ -1,0 +1,53 @@
+var should = require('should');
+var async = require('async');
+var express = require('express');
+var request = require('supertest');
+require('./lib/mongoose-connection');
+
+var app = express();
+
+describe('CustomError: index', function() {
+	var CrudGenerator = require('../index');
+	var model = require('./fixtures/model');
+	var options = {
+		errors: {
+			notFound: function() {
+				return new Error('Custom not found error');
+			}
+		}
+	};
+	var crud = new CrudGenerator(model, options);
+
+	it('should return a custom not found error for show when passed and an option to the generator', function(done) {
+		var handler = crud.show();
+		app.get('/show', handler, function(err, req, res, next) {
+			should.exist(err);
+			err.should.be.a.Error;
+			err.should.be.an.instanceOf(Error);
+			err.should.have.property('message', 'Custom not found error');
+			done();
+		});
+
+		request(app)
+		.get('/show')
+		.expect(404)
+		.end();
+	});
+
+	it('should return a custom not found error for update when passed and an option to the generator', function(done) {
+		var handler = crud.update();
+		app.get('/update', handler, function(err, req, res, next) {
+			should.exist(err);
+			err.should.be.a.Error;
+			err.should.be.an.instanceOf(Error);
+			err.should.have.property('message', 'Custom not found error');
+			done();
+		});
+
+		request(app)
+		.get('/update')
+		.expect(404)
+		.end();
+	});
+
+});


### PR DESCRIPTION
This affects both the show and update methods.

### Todo

* [x] Decide how to reuse the not found error handling for show and update