### PR TITLE
Add prev pagination option to links header output

### DIFF
--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -75,7 +75,7 @@ module.exports = {
 		}
 
 		// if not the last page, show the next and last links
-		if (next < last) {
+		if (next <= last) {
 			links.next = uri(url).query({ page: next }).toString();
 			links.last = uri(url).query({ page: last }).toString();
 		}

--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -61,18 +61,24 @@ module.exports = {
 		var count = options.count;
 		var perPage = options.perPage;
 
-		var previous = page + 1;
+		var prev = page - 1;
 		var next = page + 1;
 		var last = Math.floor(count / perPage);
 		if (count % perPage > 0) {
 			++last;
 		}
 
-		var links = {
-			// previous: '?page=' + previous,
-			next: uri(url).query({ page: next }).toString(),
-			last: uri(url).query({ page: last }).toString()
-		};
+		var links = {};
+
+		if (prev > 0) {
+			links.prev = uri(url).query({ page: prev }).toString();
+		}
+
+		// if not the last page, show the next and last links
+		if (next < last) {
+			links.next = uri(url).query({ page: next }).toString();
+			links.last = uri(url).query({ page: last }).toString();
+		}
 
 		return links;
 	}

--- a/test/pagination-test.js
+++ b/test/pagination-test.js
@@ -114,6 +114,22 @@ describe('Pagination: index', function() {
 		.expect('Link', /(rel="prev")/ig, done);
 	});
 
+	it('should not include pagination links if page count is 1', function(done) {
+		var pagination = {
+			perPage: 9999,
+			page: 1
+		};
+		var handler = crud.index();
+		app.get('/', handler);
+
+		request(app)
+		.get('/')
+		.query(pagination)
+		.expect('Content-Type', /json/)
+		// assert that rel next and last are present in the link string
+		.expect('Link', '', done);
+	});
+
 	function createRandomDocument(n, callback) {
 		var data = {
 			description: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'

--- a/test/pagination-test.js
+++ b/test/pagination-test.js
@@ -42,7 +42,7 @@ describe('Pagination: index', function() {
 	});
 	it('should paginate by length of perPage option in query params if provided', function(done) {
 		var handler = crud.index();
-		var pagination ={
+		var pagination = {
 			perPage: 30
 		};
 		app.get('/', handler);
@@ -61,7 +61,7 @@ describe('Pagination: index', function() {
 		});
 	});
 	it('should paginate by length of perPage and page option in query params if provided', function(done) {
-		var pagination ={
+		var pagination = {
 			perPage: 30,
 			page: 2
 		};
@@ -80,6 +80,38 @@ describe('Pagination: index', function() {
 			json.should.have.length(pagination.perPage);
 			done();
 		});
+	});
+
+	it('should include last and next header links if not the last page of pagination', function(done) {
+		var pagination = {
+			perPage: 30,
+			page: 1
+		};
+		var handler = crud.index();
+		app.get('/', handler);
+
+		request(app)
+		.get('/')
+		.query(pagination)
+		.expect('Content-Type', /json/)
+		// assert that rel next and last are present in the link string
+		.expect('Link', /(rel="next").*(rel="last")/ig, done); // http://www.regexr.com/3a5p9
+	});
+
+	it('should include prev header links if not the last page of pagination', function(done) {
+		var pagination = {
+			perPage: 30,
+			page: 2
+		};
+		var handler = crud.index();
+		app.get('/', handler);
+
+		request(app)
+		.get('/')
+		.query(pagination)
+		.expect('Content-Type', /json/)
+		// assert that rel next and last are present in the link string
+		.expect('Link', /(rel="prev")/ig, done);
 	});
 
 	function createRandomDocument(n, callback) {

--- a/test/pagination-test.js
+++ b/test/pagination-test.js
@@ -100,6 +100,21 @@ describe('Pagination: index', function() {
 		.expect('Link', /(rel="next").*(rel="last")/ig, done); // http://www.regexr.com/3a5p9
 	});
 
+	it('should not include last and next header links if last page', function(done) {
+		var pagination = {
+			perPage: 30,
+			page: 2
+		};
+		var handler = crud.index();
+		app.get('/', handler);
+
+		request(app)
+		.get('/')
+		.query(pagination)
+		.expect('Content-Type', /json/)
+		.expect('Link', '</?page=1>; rel="prev"', done);
+	});
+
 	it('should include prev header links if not the last page of pagination', function(done) {
 		var pagination = {
 			perPage: 30,

--- a/test/pagination-test.js
+++ b/test/pagination-test.js
@@ -112,10 +112,11 @@ describe('Pagination: index', function() {
 		.get('/')
 		.query(pagination)
 		.expect('Content-Type', /json/)
-		.expect('Link', '</?page=1>; rel="prev"', done);
+		.expect('Link', /^((?!next).)*$/i)
+		.expect('Link', /^((?!last).)*$/i, done);
 	});
 
-	it('should include prev header links if not the last page of pagination', function(done) {
+	it('should include prev header links if not the first page of pagination', function(done) {
 		var pagination = {
 			perPage: 30,
 			page: 2
@@ -127,8 +128,22 @@ describe('Pagination: index', function() {
 		.get('/')
 		.query(pagination)
 		.expect('Content-Type', /json/)
-		// assert that rel next and last are present in the link string
 		.expect('Link', /(rel="prev")/ig, done);
+	});
+
+	it('should not include prev header links if first page of pagination', function(done) {
+		var pagination = {
+			perPage: 30,
+			page: 1
+		};
+		var handler = crud.index();
+		app.get('/', handler);
+
+		request(app)
+		.get('/')
+		.query(pagination)
+		.expect('Content-Type', /json/)
+		.expect('Link', /^((?!prev).)*$/i, done);
 	});
 
 	it('should not include pagination links if page count is 1', function(done) {
@@ -143,7 +158,6 @@ describe('Pagination: index', function() {
 		.get('/')
 		.query(pagination)
 		.expect('Content-Type', /json/)
-		// assert that rel next and last are present in the link string
 		.expect('Link', '', done);
 	});
 

--- a/test/pagination-test.js
+++ b/test/pagination-test.js
@@ -21,7 +21,9 @@ describe('Pagination: index', function() {
 
 	// Create some fixture data to test pagination
 	before(function(done) {
-		async.timesSeries(50, createRandomDocument, done)
+		model.remove(function() {
+			async.timesSeries(50, createRandomDocument, done)
+		});
 	});
 
 	it('should paginate 25 (our custom setting)', function(done) {
@@ -63,7 +65,7 @@ describe('Pagination: index', function() {
 	it('should paginate by length of perPage and page option in query params if provided', function(done) {
 		var pagination = {
 			perPage: 30,
-			page: 2
+			page: 1
 		};
 		var handler = crud.index();
 		app.get('/', handler);


### PR DESCRIPTION
The 'prev' link in the links header was never being applied by the pagination module. The PR adds it in there and also adds some conditional for only sending down the relevant links when they are needed.

E.g.

* Don't send down prev on the first page
* Only send down next & last if were not on the last page

There are some tests to verify this with some regex courtesy of @benjaminpearson 