### PR TITLE
Update method changed to use mongoose set

### DIFF
--- a/lib/generators/update.js
+++ b/lib/generators/update.js
@@ -25,7 +25,7 @@ var update = function(options) {
 				return next(customErrors.notFound());
 			}
 
-			model = _.extend(model, data);
+			model.set(data);
 			model.save(function(err) {
 				if (err) {
 					return next(err);


### PR DESCRIPTION
By using mongoose’s set method, deeper object paths are updated rather than being overwritten.

http://mongoosejs.com/docs/api.html#document_Document-set